### PR TITLE
Switch from Raddocs to Apitome

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gem "pg"
 gem "puma"
 gem "jsonapi-resources", git: "https://github.com/cerebris/jsonapi-resources", branch: "master"
 gem "rspec_api_documentation"
-gem "raddocs"
+gem "apitome"
 gem "rspec-rails", "~> 3.3.0"
 gem "spring-commands-rspec", platform: :ruby
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,6 +44,10 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
+    apitome (0.1.0)
+      kramdown
+      railties
+      rspec_api_documentation
     arel (6.0.2)
     builder (3.2.2)
     byebug (5.0.0)
@@ -58,10 +62,9 @@ GEM
       railties (>= 3.0.0)
     globalid (0.3.5)
       activesupport (>= 4.1.0)
-    haml (4.0.6)
-      tilt
     i18n (0.7.0)
     json (1.8.3)
+    kramdown (1.8.0)
     loofah (2.0.2)
       nokogiri (>= 1.5.9)
     mail (2.6.3)
@@ -78,14 +81,8 @@ GEM
     pg (0.18.2-x86-mingw32)
     puma (2.12.2)
     rack (1.6.4)
-    rack-protection (1.5.3)
-      rack
     rack-test (0.6.3)
       rack (>= 1.0)
-    raddocs (0.4.0)
-      haml (~> 4.0, >= 4.0.4)
-      json (~> 1.8, >= 1.8.1)
-      sinatra (~> 1.3, >= 1.3.0)
     rails (4.2.3)
       actionmailer (= 4.2.3)
       actionpack (= 4.2.3)
@@ -144,10 +141,6 @@ GEM
       rspec (>= 3.0.0)
     shoulda-matchers (3.0.0.rc1)
       activesupport (>= 4.0.0)
-    sinatra (1.4.6)
-      rack (~> 1.4)
-      rack-protection (~> 1.4)
-      tilt (>= 1.3, < 3)
     spring (1.3.6)
     spring-commands-rspec (1.0.4)
       spring (>= 0.9.1)
@@ -159,7 +152,6 @@ GEM
       sprockets (>= 2.8, < 4.0)
     thor (0.19.1)
     thread_safe (0.3.5)
-    tilt (2.0.1)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
     tzinfo-data (1.2015.5)
@@ -170,12 +162,12 @@ PLATFORMS
   x86-mingw32
 
 DEPENDENCIES
+  apitome
   byebug
   factory_girl_rails (~> 4.5.0)
   jsonapi-resources!
   pg
   puma
-  raddocs
   rails (= 4.2.3)
   rails_12factor
   rspec-rails (~> 3.3.0)
@@ -184,6 +176,3 @@ DEPENDENCIES
   spring
   spring-commands-rspec
   tzinfo-data
-
-BUNDLED WITH
-   1.10.5

--- a/config/initializers/apitome.rb
+++ b/config/initializers/apitome.rb
@@ -1,0 +1,42 @@
+Apitome.setup do |config|
+  # This determines where the Apitome routes will be mounted. Changing this to '/api/documentation' for instance would
+  # allow you to browse to http://localhost:3000/api/documentation to see your api documentation. Set to nil and mount
+  # it yourself if you need to.
+  config.mount_at = "/docs"
+
+  # This defaults to Rails.root if left nil. If you're providing documentation for an engine using a dummy application
+  # it can be useful to set this to your engines root.. E.g. Application::Engine.root
+  config.root = nil
+
+  # This is where rspec_api_documentation outputs the JSON files. This is configurable within RAD, and so is
+  # configurable here.
+  config.doc_path = "docs"
+
+  # The title of the documentation -- If your project has a name, you'll want to put it here.
+  config.title = "Apitome Documentation"
+
+  # The main layout view for all documentation pages. By default this is pretty basic, but you may want to use your own
+  # application layout.
+  config.layout = "apitome/application"
+
+  # We're using highlight.js (https://github.com/isagalaev/highlight.js) for code highlighting, and it comes with some
+  # great themes. You can check http://softwaremaniacs.org/media/soft/highlight/test.html for themes, and enter the
+  # theme as lowercase/underscore.
+  config.code_theme = "solarized_light"
+
+  # This allows you to override the css manually. You typically want to require `apitome/application` within the
+  # override, but if you want to override it entirely you can do so.
+  config.css_override = nil
+
+  # This allows you to override the javascript manually. You typically want to require `apitome/application` within the
+  # override, but if you want to override it entirely you can do so.
+  config.js_override = nil
+
+  # You can provide a 'README' style markdown file for the documentation, which is a useful place to include general
+  # information. This path is relative to your doc_path configuration.
+  config.readme = "api.md"
+
+  # Apitome can render the documentation into a single page that uses scrollspy, or it can render the documentation on
+  # individual pages on demand. This allows you to specify which one you want, as a single page may impact performance.
+  config.single_page = true
+end

--- a/config/initializers/raddocs.rb
+++ b/config/initializers/raddocs.rb
@@ -1,4 +1,0 @@
-Raddocs.configure do |config|
-  config.api_name = "JSON API Examples"
-  config.docs_dir = "docs"
-end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,4 @@
 Rails.application.routes.draw do
-  mount Raddocs::App => "/docs"
   root to: redirect("/docs")
   jsonapi_resources :players
   jsonapi_resources :matches

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,4 @@
+Apitome Documentation
+=====================
+
+This file was automatically generated, and can be found at `docs/api.md`.


### PR DESCRIPTION
Hey, as discussed in https://github.com/cerebris/jsonapi-resources/issues/166#issuecomment-124101542 here a PR using Apitome instead of Raddocs. Looks nicer IMHO! :balloon:

![screen shot 2015-07-23 at 16 55 42](https://cloud.githubusercontent.com/assets/1322/8853654/fd9876de-315b-11e5-96d5-3c9f8e4d6a4c.png)
